### PR TITLE
Adjusting gpgcheck regex to gpgcheck.*

### DIFF
--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -474,7 +474,7 @@
 - name: "SCORED | 1.2.2 | PATCH | Ensure gpgcheck is globally activated"
   replace:
       name: /etc/yum.conf
-      regexp: "^gpgcheck=0"
+      regexp: "^gpgcheck.*"
       replace: "gpgcheck=1"
   when:
       - rhel7cis_rule_1_2_2
@@ -501,7 +501,7 @@
 - name: "SCORED | 1.2.2 | PATCH | Ensure gpgcheck is globally activated"
   replace:
       name: "{{ item.path }}"
-      regexp: "^gpgcheck=0"
+      regexp: "^gpgcheck.*"
       replace: "gpgcheck=1"
   with_items:
       - "{{ yum_repos.files }}"


### PR DESCRIPTION
Changing the regular expression in order to meet the requirement of both gpg check and AWS inspector.

The regex normalizes also strings like 'gpgcheck = 1' (e.g. those repositories added with ansible yum_repository module, when gpgcheck is set to 'yes'), converting them into 'gpgcheck=1'